### PR TITLE
Corrected data types used for temporary buffers in .inl files for scan routines and removed some warnings for 32 bit

### DIFF
--- a/include/bolt/amp/detail/scan.inl
+++ b/include/bolt/amp/detail/scan.inl
@@ -269,7 +269,7 @@ Serial_scan(
     const bool Incl,
     const T &init)
 {
-    oType  sum, temp;
+    vType  sum, temp;
     if(Incl){
       *result = *values; // assign value
       sum = *values;
@@ -281,10 +281,10 @@ Serial_scan(
     }
     for ( unsigned int i= 1; i<num; i++)
     {
-        oType currentValue = *(values + i); // convertible
+        vType currentValue = *(values + i); // convertible
         if (Incl)
         {
-            oType r = binary_op( sum, currentValue);
+            vType r = binary_op( sum, currentValue);
             *(result + i) = r;
             sum = r;
         }
@@ -418,45 +418,23 @@ scan_pick_iterator(
     const bolt::amp::control::e_RunMode runMode = ctl.getForceRunMode( );  // could be dynamic choice some day.
     if( runMode == bolt::amp::control::SerialCpu )
     {
-       std::vector<iType> scanInputBuffer(numElements);
-       std::vector<oType> scanResultBuffer(numElements);
-
-        for(unsigned int index=0; index<numElements; index++){
-            scanInputBuffer[index] = first.getContainer().getBuffer()[index];
-            scanResultBuffer[index] = result.getContainer().getBuffer()[index];
-        }
-        Serial_scan<iType, oType, BinaryFunction, T>(&(scanInputBuffer[0]), &(scanResultBuffer[0]),
-                                                     numElements, binary_op, inclusive, init);
-        for(unsigned int index=0; index<numElements; index++){
-            result.getContainer().getBuffer()[index] = scanResultBuffer[index];
-        }
+        bolt::amp::device_vector< iType >::pointer scanInputBuffer =  first.getContainer( ).data( );
+        bolt::amp::device_vector< oType >::pointer scanResultBuffer =  result.getContainer( ).data( );
+        Serial_scan<iType, oType, BinaryFunction, T>(&scanInputBuffer[first.m_Index], &scanResultBuffer[result.m_Index],
+                                                              numElements, binary_op, inclusive, init);
         return result + numElements;
     }
     else if( runMode == bolt::amp::control::MultiCoreCpu )
     {
 
 #ifdef ENABLE_TBB
-        std::vector<iType> scanInputBuffer(numElements);
-        std::vector<oType> scanResultBuffer(numElements);
-
-        //Copy the device_vector buffer to a CPU buffer
-        for(unsigned int index=0; index<numElements; index++){
-            scanInputBuffer[index] = first.getContainer().getBuffer()[index];
-            scanResultBuffer[index] = result.getContainer().getBuffer()[index];
-        }
-
+        bolt::amp::device_vector< iType >::pointer scanInputBuffer =  first.getContainer( ).data( );
+        bolt::amp::device_vector< oType >::pointer scanResultBuffer =  result.getContainer( ).data( );
         if(inclusive)
-        {
-            bolt::btbb::inclusive_scan( scanInputBuffer.begin(),  scanInputBuffer.end(), scanResultBuffer.begin(), binary_op);
-        }
+            bolt::btbb::inclusive_scan(&scanInputBuffer[first.m_Index], &scanInputBuffer[first.m_Index] + numElements, &scanResultBuffer[result.m_Index], binary_op);
         else
-        {
-            bolt::btbb::exclusive_scan(  scanInputBuffer.begin(),  scanInputBuffer.end(), scanResultBuffer.begin(), init, binary_op);
-        }
+            bolt::btbb::exclusive_scan( &scanInputBuffer[first.m_Index], &scanInputBuffer[first.m_Index] + numElements, &scanResultBuffer[result.m_Index], init, binary_op);
 
-        for(unsigned int index=0; index<numElements; index++){
-            result.getContainer().getBuffer()[index] = scanResultBuffer[index];
-        }
         return result + numElements;
 #else
 //        std::cout << "The MultiCoreCpu version of Scan with device vector is not implemented yet." << std ::endl;
@@ -547,9 +525,9 @@ size_t k0_stepNum, k1_stepNum, k2_stepNum;
     //::cl::Buffer preSumArray( ctl.context( ), CL_MEM_READ_WRITE, sizeScanBuff*sizeof(iType) );
     //::cl::Buffer postSumArray( ctl.context( ), CL_MEM_READ_WRITE, sizeScanBuff*sizeof(iType) );
 
-    concurrency::array< oType >  preSumArray( sizeScanBuff, av );
-    concurrency::array< oType >  preSumArray1( sizeScanBuff, av );
-    concurrency::array< oType > postSumArray( sizeScanBuff, av );
+    concurrency::array< iType >  preSumArray( sizeScanBuff, av );
+    concurrency::array< iType >  preSumArray1( sizeScanBuff, av );
+    concurrency::array< iType > postSumArray( sizeScanBuff, av );
 
 
     /**********************************************************************************

--- a/include/bolt/cl/detail/scan.inl
+++ b/include/bolt/cl/detail/scan.inl
@@ -241,7 +241,7 @@ Serial_scan(
     const bool Incl,
     const T &init)
 {
-    oType  sum, temp;
+    vType  sum, temp;
     if(Incl){
       *result = *values; // assign value
       sum = *values;
@@ -253,10 +253,10 @@ Serial_scan(
     }
     for ( unsigned int i= 1; i<num; i++)
     {
-        oType currentValue = *(values + i); // convertible
+        vType currentValue = *(values + i); // convertible
         if (Incl)
         {
-            oType r = binary_op( sum, currentValue);
+            vType r = binary_op( sum, currentValue);
             *(result + i) = r;
             sum = r;
         }
@@ -892,7 +892,7 @@ aProfiler.stopTrial();
     ::cl::Event kernel0Event, kernel1Event, kernel2Event, kernelAEvent;
 
                 //  Ceiling function to bump the size of the sum array to the next whole wavefront size
-    device_vector< oType >::size_type sizeScanBuff = numWorkGroupsK0;
+    device_vector< iType >::size_type sizeScanBuff = numWorkGroupsK0;
     modWgSize = (sizeScanBuff & ((kernel0_WgSize*2)-1));
                 if( modWgSize )
                 {
@@ -900,9 +900,9 @@ aProfiler.stopTrial();
                     sizeScanBuff += (kernel0_WgSize*2);
                 }
 
-    control::buffPointer preSumArray = ctrl.acquireBuffer( (sizeScanBuff)*sizeof( oType ) );
-  control::buffPointer preSumArray1 = ctrl.acquireBuffer( (sizeScanBuff)*sizeof( oType ) );
-    control::buffPointer postSumArray = ctrl.acquireBuffer( (sizeScanBuff)*sizeof( oType ) );
+    control::buffPointer preSumArray = ctrl.acquireBuffer( (sizeScanBuff)*sizeof( iType ) );
+  control::buffPointer preSumArray1 = ctrl.acquireBuffer( (sizeScanBuff)*sizeof( iType ) );
+    control::buffPointer postSumArray = ctrl.acquireBuffer( (sizeScanBuff)*sizeof( iType ) );
     //::cl::Buffer userFunctor( ctrl.context( ), CL_MEM_USE_HOST_PTR, sizeof( binary_op ), &binary_op );
     //::cl::Buffer preSumArray( ctrl.context( ), CL_MEM_READ_WRITE, sizeScanBuff*sizeof(iType) );
     //::cl::Buffer postSumArray( ctrl.context( ), CL_MEM_READ_WRITE, sizeScanBuff*sizeof(iType) );

--- a/include/bolt/cl/detail/scan_by_key.inl
+++ b/include/bolt/cl/detail/scan_by_key.inl
@@ -1078,9 +1078,9 @@ size_t k0_stepNum, k1_stepNum, k2_stepNum;
         CL_MEM_USE_HOST_PTR|CL_MEM_READ_ONLY, &aligned_binary_funct );
 
     control::buffPointer keySumArray  = ctl.acquireBuffer( sizeScanBuff*sizeof( kType ) );
-    control::buffPointer preSumArray  = ctl.acquireBuffer( sizeScanBuff*sizeof( oType ) );
-    control::buffPointer preSumArray1  = ctl.acquireBuffer( sizeScanBuff*sizeof( oType ) );
-    control::buffPointer postSumArray = ctl.acquireBuffer( sizeScanBuff*sizeof( oType ) );
+    control::buffPointer preSumArray  = ctl.acquireBuffer( sizeScanBuff*sizeof( vType ) );
+    control::buffPointer preSumArray1  = ctl.acquireBuffer( sizeScanBuff*sizeof( vType ) );
+    control::buffPointer postSumArray = ctl.acquireBuffer( sizeScanBuff*sizeof( vType ) );
     cl_uint ldsKeySize, ldsValueSize;
 
 
@@ -1095,7 +1095,7 @@ aProfiler.set(AsyncProfiler::getDevice, control::SerialCpu);
     try
     {
     ldsKeySize   = static_cast< cl_uint >( (kernel0_WgSize*2) * sizeof( kType ) );
-    ldsValueSize = static_cast< cl_uint >( (kernel0_WgSize*2) * sizeof( oType ) );
+    ldsValueSize = static_cast< cl_uint >( (kernel0_WgSize*2) * sizeof( vType ) );
     V_OPENCL( kernels[0].setArg( 0, firstKey.getContainer().getBuffer()), "Error setArg kernels[ 0 ]" ); // Input keys
     V_OPENCL( kernels[0].setArg( 1, firstKey.gpuPayloadSize( ), &firstKey.gpuPayload( ) ), "Error setting a kernel argument" );
     V_OPENCL( kernels[0].setArg( 2, firstValue.getContainer().getBuffer()),"Error setArg kernels[ 0 ]" ); // Input buffer
@@ -1147,7 +1147,7 @@ aProfiler.setStepName("Setup Kernel 1");
 aProfiler.set(AsyncProfiler::device, control::SerialCpu);
 #endif
     ldsKeySize   = static_cast< cl_uint >( (kernel0_WgSize) * sizeof( kType ) );
-    ldsValueSize = static_cast< cl_uint >( (kernel0_WgSize) * sizeof( oType ) );
+    ldsValueSize = static_cast< cl_uint >( (kernel0_WgSize) * sizeof( vType ) );
     cl_uint workPerThread = static_cast< cl_uint >( sizeScanBuff / kernel1_WgSize );
     workPerThread = workPerThread ? workPerThread : 1;
 

--- a/include/bolt/cl/detail/transform_scan.inl
+++ b/include/bolt/cl/detail/transform_scan.inl
@@ -437,7 +437,7 @@ transform_scan_pick_iterator(
         bolt::cl::device_vector< iType >::pointer InputBuffer =  first.getContainer( ).data( );
         bolt::cl::device_vector< oType >::pointer ResultBuffer =  result.getContainer( ).data( );
 
-        std::transform(&InputBuffer[ first.m_Index ], &InputBuffer[first.m_Index + numElements], &ResultBuffer[ result.m_Index], unary_op);
+        std::transform(&InputBuffer[ first.m_Index ], &InputBuffer[first.m_Index] + numElements, stdext::make_checked_array_iterator(&ResultBuffer[ result.m_Index], numElements), unary_op);
         Serial_Scan<oType, BinaryFunction, T>(&ResultBuffer[ result.m_Index  ], &ResultBuffer[ result.m_Index ], numElements, binary_op, inclusive, init);
         return result + numElements;
     }
@@ -754,7 +754,7 @@ aProfiler.setArchitecture(strDeviceName);
         V_OPENCL( l_Error, "failed on getProfilingInfo<CL_PROFILING_COMMAND_END>()");
 
         size_t k0_start_cpu = aProfiler.get(k0_stepNum, AsyncProfiler::startTime);
-        size_t shift = k0_start - k0_start_cpu;
+        size_t shift = (size_t)k0_start - k0_start_cpu;
         //size_t shift = k0_start_cpu - k0_start;
 
         //std::cout << "setting step " << k0_stepNum << " attribute " << AsyncProfiler::stopTime << " to " ;

--- a/test/amp/ScanTest/ScanTest.cpp
+++ b/test/amp/ScanTest/ScanTest.cpp
@@ -1231,7 +1231,7 @@ TEST(InclusiveScan, DeviceVectorInclFloat)
     std::vector< float > refInput( length);
     std::vector< float > refOutput( length);
    
-    for(int i=0; i<length; i++) {
+    for(size_t i=0; i<length; i++) {
         input[i] = 2.f;
         refInput[i] = 2.f;
     }
@@ -1255,7 +1255,7 @@ TEST(InclusiveScan, SerialDeviceVectorInclFloat)
     std::vector< float > refInput( length);
     std::vector< float > refOutput( length);
    
-    for(int i=0; i<length; i++) {
+    for(size_t i=0; i<length; i++) {
         input[i] = 2.f;
         refInput[i] = 2.f;
     }
@@ -1282,7 +1282,7 @@ TEST(InclusiveScan, MulticoreDeviceVectorInclFloat)
     std::vector< float > refInput( length);
     std::vector< float > refOutput( length);
    
-    for(int i=0; i<length; i++) {
+    for(size_t i=0; i<length; i++) {
         input[i] = 2.f;
         refInput[i] = 2.f;
     }
@@ -1364,7 +1364,7 @@ TEST(ExclusiveScan, DeviceVectorExclFloat)
     bolt::amp::device_vector< float > output( length);
     std::vector< float > refInput( length);
     std::vector< float > refOutput( length);
-    for(int i=0; i<length; i++) {
+    for(size_t i=0; i<length; i++) {
         input[i] = 2.0f;
         if(i != length-1)
            refInput[i+1] = 2.0f;
@@ -1389,7 +1389,7 @@ TEST(ExclusiveScan, SerialDeviceVectorExclFloat)
     bolt::amp::device_vector< float > output( length);
     std::vector< float > refInput( length);
     std::vector< float > refOutput( length);
-    for(int i=0; i<length; i++) {
+    for(size_t i=0; i<length; i++) {
         input[i] = 2.0f;
         if(i != length-1)
            refInput[i+1] = 2.0f;
@@ -1416,7 +1416,7 @@ TEST(ExclusiveScan, MulticoreDeviceVectorExclFloat)
     bolt::amp::device_vector< float > output( length);
     std::vector< float > refInput( length);
     std::vector< float > refOutput( length);
-    for(int i=0; i<length; i++) {
+    for(size_t i=0; i<length; i++) {
         input[i] = 2.0f;
         if(i != length-1)
            refInput[i+1] = 2.0f;


### PR DESCRIPTION
Corrected data types used for temporary buffers in .inl files for scan routines and removed some warnings for 32 bit
