### PR TITLE
Fix various CMake issues when building on Linux 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,15 @@ else()
 endif()
 
 # Various options below on configuring the build, and how to generate the solution files
-option( BUILD_ampBolt "Create a solution that compiles Bolt for AMP" ON )
+
+if ( MSVC )
+# Only Visual Studio compiler may build Bolt for AMP
+    set(Bolt_ampDefault ON)
+else ()
+    set(Bolt_ampDefault OFF)
+endif()
+
+option( BUILD_ampBolt "Create a solution that compiles Bolt for AMP" ${Bolt_ampDefault} )
 option( BUILD_clBolt "Create a solution that compiles Bolt for OpenCL" ON )
 option( BUILD_StripSymbols "When making debug builds, remove symbols and program database files" OFF )
  

--- a/bench/cl/Fill/CMakeLists.txt
+++ b/bench/cl/Fill/CMakeLists.txt
@@ -16,7 +16,7 @@
 ############################################################################                                                                                     
 
 # List the names of common files to compile across all platforms
-set( clBolt.Bench.Fill.Source stdafx.cpp Fill.cpp )
+set( clBolt.Bench.Fill.Source stdafx.cpp fill.cpp )
 set( clBolt.Bench.Fill.Headers stdafx.h targetver.h ${BOLT_INCLUDE_DIR}/bolt/cl/fill.h )
 
 set( clBolt.Bench.Fill.Files ${clBolt.Bench.Fill.Source} ${clBolt.Bench.Fill.Headers} )

--- a/bench/cl/Generate/CMakeLists.txt
+++ b/bench/cl/Generate/CMakeLists.txt
@@ -16,7 +16,7 @@
 ############################################################################                                                                                     
 
 # List the names of common files to compile across all platforms
-set( clBolt.Bench.Generate.Source stdafx.cpp Generate.cpp )
+set( clBolt.Bench.Generate.Source stdafx.cpp generate.cpp )
 set( clBolt.Bench.Generate.Headers stdafx.h targetver.h ${BOLT_INCLUDE_DIR}/bolt/cl/generate.h )
 
 set( clBolt.Bench.Generate.Files ${clBolt.Bench.Generate.Source} ${clBolt.Bench.Generate.Headers} )

--- a/bench/cl/Reduce/CMakeLists.txt
+++ b/bench/cl/Reduce/CMakeLists.txt
@@ -16,7 +16,7 @@
 ############################################################################                                                                                     
 
 # List the names of common files to compile across all platforms
-set( clBolt.Bench.Reduce.Source stdafx.cpp Reduce.cpp )
+set( clBolt.Bench.Reduce.Source stdafx.cpp reduce.cpp )
 set( clBolt.Bench.Reduce.Headers stdafx.h targetver.h ${BOLT_INCLUDE_DIR}/bolt/cl/reduce.h ${BOLT_INCLUDE_DIR}/bolt/cl/detail/reduce.inl)
 
 set( clBolt.Bench.Reduce.Files ${clBolt.Bench.Reduce.Source} ${clBolt.Bench.Reduce.Headers} )

--- a/bench/cl/Scan/CMakeLists.txt
+++ b/bench/cl/Scan/CMakeLists.txt
@@ -16,8 +16,8 @@
 ############################################################################                                                                                     
 
 # List the names of common files to compile across all platforms
-set( clBolt.Bench.Scan.Source stdafx.cpp Scan.cpp )
-set( clBolt.Bench.Scan.Headers stdafx.h targetver.h ${BOLT_INCLUDE_DIR}/bolt/cl/Scan.h )
+set( clBolt.Bench.Scan.Source stdafx.cpp scan.cpp )
+set( clBolt.Bench.Scan.Headers stdafx.h targetver.h ${BOLT_INCLUDE_DIR}/bolt/cl/scan.h )
 
 set( clBolt.Bench.Scan.Files ${clBolt.Bench.Scan.Source} ${clBolt.Bench.Scan.Headers} )
 

--- a/bench/cl/StableSort/CMakeLists.txt
+++ b/bench/cl/StableSort/CMakeLists.txt
@@ -20,8 +20,8 @@ set( clBolt.Bench.StableSort.Source
         StableSortBench.cpp )
 
 set( clBolt.Bench.StableSort.Headers stdafx.h 
-        ${BOLT_INCLUDE_DIR}/bolt/cl/StableSort.h 
-        ${BOLT_INCLUDE_DIR}/bolt/cl/detail/StableSort.inl)
+        ${BOLT_INCLUDE_DIR}/bolt/cl/stablesort.h 
+        ${BOLT_INCLUDE_DIR}/bolt/cl/detail/stablesort.inl)
 
 set( clBolt.Bench.StableSort.Files 
         ${clBolt.Bench.StableSort.Source} 

--- a/bench/cl/Transform/CMakeLists.txt
+++ b/bench/cl/Transform/CMakeLists.txt
@@ -16,7 +16,7 @@
 ############################################################################                                                                                     
 
 # List the names of common files to compile across all platforms
-set( clBolt.Bench.Transform.Source stdafx.cpp Transform.cpp )
+set( clBolt.Bench.Transform.Source stdafx.cpp transform.cpp )
 set( clBolt.Bench.Transform.Headers stdafx.h targetver.h ${BOLT_INCLUDE_DIR}/bolt/cl/transform.h )
 
 set( clBolt.Bench.Transform.Files ${clBolt.Bench.Transform.Source} ${clBolt.Bench.Transform.Headers} )

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -71,13 +71,20 @@ else()
 	message( STATUS "32bit build - FIND_LIBRARY_USE_LIB64_PATHS FALSE" )
 endif()
 
+# Only Visual Studio may build Bolt with C++AMP as of now
+if( MSVC )
+	set(Bolt_Amp_default ON)
+else()
+	set(Bolt_Amp_default OFF)
+endif()
+
 # Various options below on configuring the build, and how to generate the solution files
 option( BUILD_Boost "Install and Compile Boost as an external dependency" ON )
 option( BUILD_Doxygen "Install Doxygen as an external dependency" ON )
 option( BUILD_Bolt "Setup Bolt to use all the external dependencies" ON )
 option( BUILD_gTest "Install googleTest as an external dependency" ON )
 option( BUILD_TBB "Install TBB as an external dependency" OFF )
-option( BUILD_AMP "Generate projects that use the AMP backend" ON )
+option( BUILD_AMP "Generate projects that use the AMP backend" ${Bolt_Amp_default} )
 option( BUILD_OpenCL "Generate projects that use the OpenCL backend" ON )
 option( BUILD_StripSymbols "When making debug builds, remove symbols and program database files" OFF )
 

--- a/superbuild/ExternalBoost.cmake
+++ b/superbuild/ExternalBoost.cmake
@@ -30,7 +30,17 @@ message( STATUS "ext.Boost_VERSION: " ${ext.Boost_VERSION} )
 # message( STATUS "status: " ${fileStatus} )
 # message( STATUS "log: " ${fileLog} )
 
-set( Boost.Command b2 -j 4 --with-program_options --with-thread --with-system --with-date_time --with-chrono )
+# Initialize various command names based on platform
+if ( UNIX )
+        set(Boost.B2 "./b2")
+	set(Boost.Bootstrap "./bootstrap.sh")
+else( )
+        set(Boost.B2 "b2")
+	set(Boost.Bootstrap "bootstrap.bat")
+endif( )
+
+
+set( Boost.Command ${Boost.B2} -j 4 --with-program_options --with-thread --with-system --with-date_time --with-chrono )
 
 if( Bolt_BUILD64 )
 	list( APPEND Boost.Command address-model=64 )
@@ -64,7 +74,7 @@ ExternalProject_Add(
 	PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/boost
     URL ${ext.Boost_URL}
 	URL_MD5 f310a8198318c10e5e4932a07c755a6a
-    UPDATE_COMMAND "bootstrap.bat"
+    UPDATE_COMMAND ${Boost.Bootstrap}
 #    PATCH_COMMAND ""
 	CONFIGURE_COMMAND ""
 	BUILD_COMMAND ${Boost.Command}

--- a/test/cl/ControlTest/CMakeLists.txt
+++ b/test/cl/ControlTest/CMakeLists.txt
@@ -16,7 +16,7 @@
 ############################################################################                                                                                     
 
 # List the names of common files to compile across all platforms
-set( clBolt.Test.Control.Source stdafx.cpp Control.test.cpp )
+set( clBolt.Test.Control.Source stdafx.cpp control.test.cpp )
 set( clBolt.Test.Control.Headers stdafx.h targetver.h ${BOLT_INCLUDE_DIR}/bolt/cl/control.h )
 
 set( clBolt.Test.Control.Files ${clBolt.Test.Control.Source} ${clBolt.Test.Control.Headers} )

--- a/test/cl/StableSortTest/CMakeLists.txt
+++ b/test/cl/StableSortTest/CMakeLists.txt
@@ -23,8 +23,8 @@ set( clBolt.Test.StableSort.Source
 
 set( clBolt.Test.StableSort.Headers   
         ${BOLT_CL_TEST_DIR}/common/myocl.h
-        ${BOLT_INCLUDE_DIR}/bolt/cl/StableSort.h
-        ${BOLT_INCLUDE_DIR}/bolt/cl/detail/StableSort.inl )
+        ${BOLT_INCLUDE_DIR}/bolt/cl/stablesort.h
+        ${BOLT_INCLUDE_DIR}/bolt/cl/detail/stablesort.inl )
 
 set( clBolt.Test.StableSort.Files 
         ${clBolt.Test.StableSort.Source} 


### PR DESCRIPTION
The following commits fixes various issues when building Bolt on Linux:
- Do not enable amp build by default unless VS compiler is used
- Correctly call bootstrap and b2 when building boost
- Correct some filename cases

So far, compilation still fail with g++-4.7 but at least compilation starts. 
